### PR TITLE
Correct values.schema.json

### DIFF
--- a/templates/cluster/demo-openstack-standalone-cp-0.0.1/values.schema.json
+++ b/templates/cluster/demo-openstack-standalone-cp-0.0.1/values.schema.json
@@ -59,7 +59,7 @@
       "type": "object",
       "description": "Labels to apply to the cluster",
       "required": [],
-      }
+      "additionalProperties": true
     },    
     "identityRef": {
       "type": "object",

--- a/templates/cluster/demo-openstack-standalone-cp-0.0.2/values.schema.json
+++ b/templates/cluster/demo-openstack-standalone-cp-0.0.2/values.schema.json
@@ -59,8 +59,8 @@
       "type": "object",
       "description": "Labels to apply to the cluster",
       "required": [],
-      }
-    },    
+      "additionalProperties": true
+    },   
     "identityRef": {
       "type": "object",
       "description": "OpenStack cluster identity object reference",


### PR DESCRIPTION
Example helm charts for OpenStack have broken values.schema.json files.