### PR TITLE
Add support for upgrading test2 cluster in demo2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,14 +412,27 @@ apply-cluster-deployment-aws-test1-0.0.2: CLUSTERNAME = test1
 apply-cluster-deployment-aws-test1-0.0.2: template_path = clusterDeployments/aws/0.0.2.yaml
 apply-cluster-deployment-aws-test1-0.0.2: ## Upgrade cluster deployment test1 to version 0.0.2
 
+apply-cluster-deployment-aws-test2-0.0.2: CLUSTERNAME = test2
+apply-cluster-deployment-aws-test2-0.0.2: template_path = clusterDeployments/aws/0.0.2.yaml
+apply-cluster-deployment-aws-test2-0.0.2: ## Upgrade cluster deployment test2 to version 0.0.2
+
 apply-cluster-deployment-azure-test1-0.0.2: CLUSTERNAME = test1
 apply-cluster-deployment-azure-test1-0.0.2: template_path = clusterDeployments/azure/0.0.2.yaml
 apply-cluster-deployment-azure-test1-0.0.2: .check-variable-azure-sp-subscription-id
 apply-cluster-deployment-azure-test1-0.0.2: ## Upgrade cluster deployment test1 to version 0.0.2
 
+apply-cluster-deployment-azure-test2-0.0.2: CLUSTERNAME = test2
+apply-cluster-deployment-azure-test2-0.0.2: template_path = clusterDeployments/azure/0.0.2.yaml
+apply-cluster-deployment-azure-test2-0.0.2: .check-variable-azure-sp-subscription-id
+apply-cluster-deployment-azure-test2-0.0.2: ## Upgrade cluster deployment test2 to version 0.0.2
+
 apply-cluster-deployment-openstack-test1-0.0.2: CLUSTERNAME = test1
 apply-cluster-deployment-openstack-test1-0.0.2: template_path = clusterDeployments/openstack/0.0.2.yaml
 apply-cluster-deployment-openstack-test1-0.0.2: ## Upgrade cluster deployment test1 to version 0.0.2	
+
+apply-cluster-deployment-openstack-test2-0.0.2: CLUSTERNAME = test2
+apply-cluster-deployment-openstack-test2-0.0.2: template_path = clusterDeployments/openstack/0.0.2.yaml
+apply-cluster-deployment-openstack-test2-0.0.2: ## Upgrade cluster deployment test2 to version 0.0.2
 
 ##@ Demo 3
 


### PR DESCRIPTION
Was able to upgrade my `test2` cluster from demo1 with this updated demo2 code:

```
$ make apply-cluster-deployment-aws-test2-0.0.2
Applying changes:
diff --color -N -u /tmp/LIVE-2629861445/k0rdent.mirantis.com.v1alpha1.ClusterDeployment.k0rdent.k0rdent-aws-test2-moshiur /tmp/MERGED-3589346377/k0rdent.mirantis.com.v1alpha1.ClusterDeployment.k0rdent.k0rdent-aws-test2-moshiur
--- /tmp/LIVE-2629861445/k0rdent.mirantis.com.v1alpha1.ClusterDeployment.k0rdent.k0rdent-aws-test2-moshiur      2025-02-11 15:35:46.758117913 +0000
+++ /tmp/MERGED-3589346377/k0rdent.mirantis.com.v1alpha1.ClusterDeployment.k0rdent.k0rdent-aws-test2-moshiur    2025-02-11 15:35:46.762117936 +0000
@@ -7,7 +7,7 @@
   creationTimestamp: "2025-02-11T14:45:41Z"
   finalizers:
   - k0rdent.mirantis.com/cluster-deployment
-  generation: 1
+  generation: 2
   labels:
     k0rdent.mirantis.com/component: kcm
   name: k0rdent-aws-test2-moshiur
@@ -31,7 +31,7 @@
   serviceSpec:
     priority: 100
     stopOnConflict: false
-  template: demo-aws-standalone-cp-0.0.1
+  template: demo-aws-standalone-cp-0.0.2
 status:
   availableUpgrades:
   - demo-aws-standalone-cp-0.0.2
clusterdeployment.k0rdent.mirantis.com/k0rdent-aws-test2-moshiur configured

ubuntu@ip-172-16-10-234:~/Github/demos$ PATH=$PATH:./bin kubectl -n k0rdent get machines
NAME                                       CLUSTER                     NODENAME                                   PROVIDERID                              PHASE     AGE     VERSION
k0rdent-aws-test1-moshiur-cp-0             k0rdent-aws-test1-moshiur   k0rdent-aws-test1-moshiur-cp-0             aws:///us-east-1a/i-02800b76b6b693fad   Running   53m     v1.31.3+k0s.0
k0rdent-aws-test1-moshiur-md-mwh97-bvldt   k0rdent-aws-test1-moshiur   k0rdent-aws-test1-moshiur-md-mwh97-bvldt   aws:///us-east-1a/i-0fcbe1e03123330da   Running   40m     v1.31.3
k0rdent-aws-test1-moshiur-md-mwh97-z6psr   k0rdent-aws-test1-moshiur   k0rdent-aws-test1-moshiur-md-mwh97-z6psr   aws:///us-east-1a/i-04452c20c54ccaf29   Running   36m     v1.31.3
k0rdent-aws-test2-moshiur-cp-0             k0rdent-aws-test2-moshiur   k0rdent-aws-test2-moshiur-cp-0             aws:///us-east-1a/i-09a8027b22ddf3db0   Running   53m     v1.31.3+k0s.0
k0rdent-aws-test2-moshiur-md-6lzfr-fw2ns   k0rdent-aws-test2-moshiur   k0rdent-aws-test2-moshiur-md-6lzfr-fw2ns   aws:///us-east-1a/i-030ea3b6a9e69bb56   Running   2m48s   v1.31.3
k0rdent-aws-test2-moshiur-md-6lzfr-j7pms   k0rdent-aws-test2-moshiur   k0rdent-aws-test2-moshiur-md-6lzfr-j7pms   aws:///us-east-1a/i-027be4c69f23beb41   Running   5m43s   v1.31.3

```